### PR TITLE
fix - require gem before usage

### DIFF
--- a/lib/craftar.rb
+++ b/lib/craftar.rb
@@ -1,3 +1,5 @@
+require 'httmultiparty'
+
 require 'craftar/base'
 
 require 'craftar/app'


### PR DESCRIPTION
require gem otherwise there is a error thrown: uninitialized constant Craftar::Base::HTTMultiParty